### PR TITLE
Proposed changes

### DIFF
--- a/lib/bloc_navigation_bloc/navigation_bloc.dart
+++ b/lib/bloc_navigation_bloc/navigation_bloc.dart
@@ -14,7 +14,7 @@ enum NavigationEvents {
 abstract class NavigationStates {}
 
 class NavigationBloc extends Bloc<NavigationEvents, NavigationStates> {
-  NavigationBloc(NavigationStates initialState) : super(initialState);
+  NavigationBloc() : super(initialState);
 
   @override
   NavigationStates get initialState => const HomePage();


### PR DESCRIPTION
Because of below code, the navigation bloc is requiring an initial state.

`NavigationBloc(NavigationStates initialState) : super(initialState);`

You don't need to have a constructor with 
`(NavigationStates initialState)`, remove this and it will remove the error.

**Why this will work?**
because the super constructor will read already defined initialState.